### PR TITLE
cast string to float

### DIFF
--- a/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
+++ b/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
@@ -24,7 +24,7 @@ class QueueStatsOverview extends BaseWidget
         return [
             Card::make('Total Jobs Executed', $aggregatedInfo->count ?? 0),
             Card::make('Total Execution Time', ($aggregatedInfo->total_time_elapsed ?? 0).'s'),
-            Card::make('Average Execution Time', ceil($aggregatedInfo->average_time_elapsed).'s' ?? 0),
+            Card::make('Average Execution Time', ceil((float)$aggregatedInfo->average_time_elapsed).'s' ?? 0),
         ];
     }
 }


### PR DESCRIPTION
newer versions of php require argument to be float or int; not a string