### PR TITLE
Sort queue monitor table by started_at descending by default

### DIFF
--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -27,7 +27,8 @@ class QueueMonitorResource extends Resource
                     ->maxLength(255),
                 Forms\Components\TextInput::make('queue')
                     ->maxLength(255),
-                Forms\Components\DateTimePicker::make('started_at'),
+                Forms\Components\DateTimePicker::make('started_at')
+                     ->sortable(),
                 Forms\Components\DateTimePicker::make('finished_at'),
                 Forms\Components\Toggle::make('failed')
                     ->required(),
@@ -35,7 +36,7 @@ class QueueMonitorResource extends Resource
                     ->required(),
                 Forms\Components\Textarea::make('exception_message')
                     ->maxLength(65535),
-            ]);
+            ])->defaultSort('started_at', 'desc');
     }
 
     public static function table(Table $table): Table


### PR DESCRIPTION
In my eyes, it makes the most sense to show the most recent job first, which is why I'm proposing to sort the table by started_at descending. 