### PR TITLE
Filament v3 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `filament-jobs-monitor` will be documented in this file.
 
+## 2.0.0 - 2023-08-09
+
+- Add support for Filament v3
+- Implement a configurable panel plugin class
+- Make table columns sortable
+- Add a configurable navigation menu resource sort order
+- Add a toggle to show a job count badge in the navigation menu
+- Add a configuration option to customize the QueueMonitorResource model
+- Split the resource label into singular and plural
+
 ## 1.3.0 - 2023-07-13
 
 - Jobs are sorted by started date from the most recent to the oldest
@@ -16,7 +26,7 @@ https://github.com/croustibat/filament-jobs-monitor/releases/tag/1.2.0
 Thanks to the contributors <3
 ## 1.1.0 - 2023-06-13
 
-- Thanks to @cntabana there's now a config file to enable/disable the navigation menu 
+- Thanks to @cntabana there's now a config file to enable/disable the navigation menu
 ## 1.0.0 - 2023-05-29
 
 - Initial release : this FilamentPHP plugin contains files to monitor queue jobs. It is compatible with all drivers.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,24 @@ This is a package to monitor background jobs for FilamentPHP. It is inspired by 
 
 ## Installation
 
-You can install the package via composer:
+Install the package via composer:
 
 ```bash
 composer require croustibat/filament-jobs-monitor
 ```
-You can publish the config file with:
+
+Publish and run the migrations using:
+
+```bash
+php artisan vendor:publish --tag="filament-jobs-monitor-migrations"
+php artisan migrate
+```
+
+## Usage
+
+### Configuration
+
+The global plugin config can be published using the command below:
 
 ```bash
 php artisan vendor:publish --tag="filament-jobs-monitor-config"
@@ -27,36 +39,62 @@ This is the content of the published config file:
 
 ```php
 return [
-    'navigation' => [
+    'resources' => [
         'enabled' => true,
-        'group_label' => 'Settings',
-        'icon' => 'heroicon-o-chip',
+        'label' => 'Job',
+        'plural_label' => 'Jobs',
+        'navigation_group' => 'Settings',
+        'navigation_icon' => 'heroicon-o-cpu-chip',
+        'navigation_sort' => null,
+        'navigation_count_badge' => false,
+        'resource' => Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource::class,
+    ],
+    'pruning' => [
+        'enabled' => true,
+        'retention_days' => 7,
     ],
 ];
 ```
 
-You can publish and run the migrations with:
+### Using Filament Panels
 
-```bash
-php artisan vendor:publish --tag="filament-jobs-monitor-migrations"
-php artisan migrate
+If you are using Filament Panels, you can register the Plugin to your Panel configuration. This will register the plugin's resources as well as allow you to set configuration using optional chainable methods.
+
+```php
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            \Croustibat\FilamentJobsMonitor\FilamentJobsMonitorPlugin::make()
+                ->label('Job')
+                ->pluralLabel('Jobs')
+                ->enableNavigation(true)
+                ->navigationIcon('heroicon-o-cpu-chip')
+                ->navigationGroup('Settings')
+                ->navigationSort(5)
+                ->navigationCountBadge(true)
+                ->enablePruning(true)
+                ->pruningRetention(7)
+                ->resource(\App\Filament\Resources\CustomJobMonitorResource::class)
+        ]);
+}
 ```
 
 ## Usage
 
-Just run a Background Job and go to the route `/admin/queue-monitors` to see the jobs. 
+Just run a Background Job and go to the route `/admin/queue-monitors` to see the jobs.
 
 ## Example
 
 Go to [example](./examples/) folder to see a Job example file.
 
-Then you can call your Job with the following code :
+Then you can call your Job with the following code:
 
 ```php
     public static function table(Table $table): Table
     {
         return $table
-        
+
         // rest of your code
         ...
 

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,9 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "filament/filament": "^2.0",
-        "illuminate/contracts": "^9.0 || ^10.0",
-        "ryangjchandler/filament-progress-column": "^0.3.2",
+        "php": "^8.1",
+        "filament/filament": "^3.0",
+        "illuminate/contracts": "^10.0",
         "spatie/laravel-package-tools": "^1.13.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.1|^8.2",
         "filament/filament": "^3.0",
         "illuminate/contracts": "^10.0",
         "spatie/laravel-package-tools": "^1.13.5"

--- a/config/filament-jobs-monitor.php
+++ b/config/filament-jobs-monitor.php
@@ -1,14 +1,18 @@
 <?php
 
-// config for Croustibat/FilamentJobsMonitor
 return [
-    'navigation' => [
+    'resources' => [
         'enabled' => true,
-        'group_label' => 'Settings',
-        'icon' => 'heroicon-o-chip',
+        'label' => 'Job',
+        'plural_label' => 'Jobs',
+        'navigation_group' => 'Settings',
+        'navigation_icon' => 'heroicon-o-cpu-chip',
+        'navigation_sort' => null,
+        'navigation_count_badge' => false,
+        'resource' => Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource::class,
     ],
     'pruning' => [
-        'activate' => true,
+        'enabled' => true,
         'retention_days' => 7,
     ],
 ];

--- a/src/FilamentJobsMonitorPlugin.php
+++ b/src/FilamentJobsMonitorPlugin.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Croustibat\FilamentJobsMonitor;
+
+use Closure;
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+use Filament\Support\Concerns\EvaluatesClosures;
+
+class FilamentJobsMonitorPlugin implements Plugin
+{
+    use EvaluatesClosures;
+
+    /**
+     * The resource label.
+     */
+    protected string|Closure|null $label = null;
+
+    /**
+     * The plural resource label.
+     */
+    protected string|Closure|null $pluralLabel = null;
+
+    /**
+     * The resource navigation status.
+     */
+    protected ?bool $navigation = null;
+
+    /**
+     * The resource navigation group.
+     */
+    protected ?string $navigationGroup = null;
+
+    /**
+     * The resource navigation icon.
+     */
+    protected ?string $navigationIcon = null;
+
+    /**
+     * The resource navigation sorting order.
+     */
+    protected ?int $navigationSort = null;
+
+    /**
+     * The resource navigation count badge status.
+     */
+    protected ?bool $navigationCountBadge = null;
+
+    /**
+     * The pruning status.
+     */
+    protected ?bool $pruning = null;
+
+    /**
+     * The pruning retention.
+     */
+    protected ?int $pruningRetention = null;
+
+    /**
+     * The resource class.
+     */
+    protected ?string $resource = null;
+
+    /**
+     * Get the plugin identifier.
+     */
+    public function getId(): string
+    {
+        return 'filament-jobs-monitor';
+    }
+
+    /**
+     * Register the plugin.
+     */
+    public function register(Panel $panel): void
+    {
+        $panel->resources([
+            $this->getResource(),
+        ]);
+    }
+
+    /**
+     * Boot the plugin.
+     */
+    public function boot(Panel $panel): void
+    {
+        //
+    }
+
+    /**
+     * Make a new instance of the plugin.
+     */
+    public static function make(): static
+    {
+        return app(static::class);
+    }
+
+    /**
+     * Get the plugin instance.
+     */
+    public static function get(): static
+    {
+        return filament(app(static::class)->getId());
+    }
+
+    /**
+     * Get the resource class.
+     */
+    public function getResource(): string
+    {
+        return $this->resource ?? config('filament-jobs-monitor.resources.resource');
+    }
+
+    /**
+     * Set the resource class.
+     */
+    public function resource(string $resource): static
+    {
+        $this->resource = $resource;
+
+        return $this;
+    }
+
+    /**
+     * Get the resource label.
+     */
+    public function getLabel(): ?string
+    {
+        return $this->evaluate($this->label) ?? config('filament-jobs-monitor.resources.label');
+    }
+
+    /**
+     * Set the resource label.
+     */
+    public function label(string $label): static
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Get the plural resource label.
+     */
+    public function getPluralLabel(): ?string
+    {
+        return $this->evaluate($this->pluralLabel) ?? config('filament-jobs-monitor.resources.plural_label');
+    }
+
+    /**
+     * Set the plural resource label.
+     */
+    public function pluralLabel(string $pluralLabel): static
+    {
+        $this->pluralLabel = $pluralLabel;
+
+        return $this;
+    }
+
+    /**
+     * Get the resource navigation group.
+     */
+    public function getNavigationGroup(): ?string
+    {
+        return $this->navigationGroup ?? config('filament-jobs-monitor.resources.navigation_group');
+    }
+
+    /**
+     * Set the resource navigation group.
+     */
+    public function navigationGroup(string $navigationGroup): static
+    {
+        $this->navigationGroup = $navigationGroup;
+
+        return $this;
+    }
+
+    /**
+     * Get the resource icon.
+     */
+    public function getNavigationIcon(): ?string
+    {
+        return $this->navigationIcon ?? config('filament-jobs-monitor.resources.navigation_icon');
+    }
+
+    /**
+     * Set the resource icon.
+     */
+    public function navigationIcon(string $navigationIcon): static
+    {
+        $this->navigationIcon = $navigationIcon;
+
+        return $this;
+    }
+
+    /**
+     * Get the resource sort.
+     */
+    public function getNavigationSort(): ?int
+    {
+        return $this->navigationSort ?? config('filament-jobs-monitor.resources.navigation_sort');
+    }
+
+    /**
+     * Set the resource sort.
+     */
+    public function navigationSort(int $navigationSort): static
+    {
+        $this->navigationSort = $navigationSort;
+
+        return $this;
+    }
+
+    /**
+     * Get the resource navigation count badge status.
+     */
+    public function getNavigationCountBadge(): ?bool
+    {
+        return $this->navigationCountBadge ?? config('filament-jobs-monitor.resources.navigation_count_badge');
+    }
+
+    /**
+     * Set the resource navigation count badge status.
+     */
+    public function navigationCountBadge(bool $navigationCountBadge = true): static
+    {
+        $this->navigationCountBadge = $navigationCountBadge;
+
+        return $this;
+    }
+
+    /**
+     * Determine whether the resource navigation is enabled.
+     */
+    public function shouldRegisterNavigation(): bool
+    {
+        return $this->navigation ?? config('filament-jobs-monitor.resources.enabled');
+    }
+
+    /**
+     * Enable the resource navigation.
+     */
+    public function enableNavigation(bool $status = true): static
+    {
+        $this->navigation = $status;
+
+        return $this;
+    }
+
+    /**
+     * Get the pruning status.
+     */
+    public function getPruning(): ?bool
+    {
+        return $this->pruning ?? config('filament-jobs-monitor.pruning.enabled');
+    }
+
+    /**
+     * Set the pruning status.
+     */
+    public function enablePruning(bool $status = true): static
+    {
+        $this->pruning = $status;
+
+        return $this;
+    }
+
+    /**
+     * Get the pruning retention.
+     */
+    public function getPruningRetention(): ?int
+    {
+        return $this->pruningRetention ?? config('filament-jobs-monitor.pruning.retention_days');
+    }
+
+    /**
+     * Set the pruning retention.
+     */
+    public function pruningRetention(int $pruningRetention): static
+    {
+        $this->pruningRetention = $pruningRetention;
+
+        return $this;
+    }
+
+    /**
+     * Get the resource breadcrumb.
+     */
+    public function getBreadcrumb(): string
+    {
+        return __('filament-jobs-monitor::translations.breadcrumb');
+    }
+}

--- a/src/FilamentJobsMonitorServiceProvider.php
+++ b/src/FilamentJobsMonitorServiceProvider.php
@@ -2,21 +2,14 @@
 
 namespace Croustibat\FilamentJobsMonitor;
 
-use Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource;
-use Filament\PluginServiceProvider;
 use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 
-class FilamentJobsMonitorServiceProvider extends PluginServiceProvider
+class FilamentJobsMonitorServiceProvider extends PackageServiceProvider
 {
-    public static string $name = 'filament-jobs-monitor';
-
-    protected array $resources = [
-        QueueMonitorResource::class,
-    ];
-
     public function configurePackage(Package $package): void
     {
-        $package->name(static::$name)
+        $package->name('filament-jobs-monitor')
             ->hasConfigFile()
             ->hasTranslations()
             ->hasMigration('create_filament-jobs-monitor_table');

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -2,6 +2,7 @@
 
 namespace Croustibat\FilamentJobsMonitor\Models;
 
+use Croustibat\FilamentJobsMonitor\FilamentJobsMonitorPlugin;
 use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -103,8 +104,8 @@ class QueueMonitor extends Model
      */
     public function prunable()
     {
-        if (config('filament-jobs-monitor.pruning.activate')) {
-            return static::where('created_at', '<=', now()->subDays(config('filament-jobs-monitor.pruning.retention_days')));
+        if (FilamentJobsMonitorPlugin::get()->getPruning()) {
+            return static::where('created_at', '<=', now()->subDays(FilamentJobsMonitorPlugin::get()->getPruningRetention()));
         }
 
         return false;

--- a/src/QueueMonitorProvider.php
+++ b/src/QueueMonitorProvider.php
@@ -78,7 +78,7 @@ class QueueMonitorProvider extends ServiceProvider
     /**
      * Finish Queue Monitoring for Job.
      */
-    protected static function jobFinished(JobContract $job, bool $failed = false, ?\Throwable $exception = null): void
+    protected static function jobFinished(JobContract $job, bool $failed = false, \Throwable $exception = null): void
     {
         $monitor = QueueMonitor::query()
             ->where('job_id', self::getJobId($job))

--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -28,8 +28,7 @@ class QueueMonitorResource extends Resource
                     ->maxLength(255),
                 Forms\Components\TextInput::make('queue')
                     ->maxLength(255),
-                Forms\Components\DateTimePicker::make('started_at')
-                    ->sortable(),
+                Forms\Components\DateTimePicker::make('started_at'),
                 Forms\Components\DateTimePicker::make('finished_at'),
                 Forms\Components\Toggle::make('failed')
                     ->required(),
@@ -37,7 +36,7 @@ class QueueMonitorResource extends Resource
                     ->required(),
                 Forms\Components\Textarea::make('exception_message')
                     ->maxLength(65535),
-            ])->defaultSort('started_at', 'desc');
+            ]);
     }
 
     public static function table(Table $table): Table

--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -6,12 +6,15 @@ use Croustibat\FilamentJobsMonitor\FilamentJobsMonitorPlugin;
 use Croustibat\FilamentJobsMonitor\Models\QueueMonitor;
 use Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource\Pages;
 use Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource\Widgets\QueueStatsOverview;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
-use Filament\Tables;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Str;
-use RyanChandler\FilamentProgressColumn\ProgressColumn;
 
 class QueueMonitorResource extends Resource
 {
@@ -21,20 +24,20 @@ class QueueMonitorResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('job_id')
+                TextInput::make('job_id')
                     ->required()
                     ->maxLength(255),
-                Forms\Components\TextInput::make('name')
+                TextInput::make('name')
                     ->maxLength(255),
-                Forms\Components\TextInput::make('queue')
+                TextInput::make('queue')
                     ->maxLength(255),
-                Forms\Components\DateTimePicker::make('started_at'),
-                Forms\Components\DateTimePicker::make('finished_at'),
-                Forms\Components\Toggle::make('failed')
+                DateTimePicker::make('started_at'),
+                DateTimePicker::make('finished_at'),
+                Toggle::make('failed')
                     ->required(),
-                Forms\Components\TextInput::make('attempt')
+                TextInput::make('attempt')
                     ->required(),
-                Forms\Components\Textarea::make('exception_message')
+                Textarea::make('exception_message')
                     ->maxLength(65535),
             ]);
     }
@@ -43,7 +46,7 @@ class QueueMonitorResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('status')
+                TextColumn::make('status')
                     ->badge()
                     ->label(__('filament-jobs-monitor::translations.status'))
                     ->sortable()
@@ -53,32 +56,25 @@ class QueueMonitorResource extends Resource
                         'succeeded' => 'success',
                         'failed' => 'danger',
                     }),
-                Tables\Columns\TextColumn::make('name')
+                TextColumn::make('name')
                     ->label(__('filament-jobs-monitor::translations.name'))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('queue')
+                TextColumn::make('queue')
                     ->label(__('filament-jobs-monitor::translations.queue'))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('progress')
+                TextColumn::make('progress')
                     ->label(__('filament-jobs-monitor::translations.progress'))
                     ->formatStateUsing(fn (string $state) => "{$state}%")
                     ->sortable(),
-                // ProgressColumn::make('progress')->label(__('filament-jobs-monitor::translations.progress'))->color('warning'),
-                Tables\Columns\TextColumn::make('started_at')
+                TextColumn::make('started_at')
                     ->label(__('filament-jobs-monitor::translations.started_at'))
                     ->since()
                     ->sortable(),
             ])
+            ->defaultSort('started_at', 'desc')
             ->bulkActions([
-                Tables\Actions\DeleteBulkAction::make(),
+                DeleteBulkAction::make(),
             ]);
-    }
-
-    public static function getRelations(): array
-    {
-        return [
-            //
-        ];
     }
 
     public static function getNavigationBadge(): ?string

--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -60,6 +60,10 @@ class QueueMonitorResource extends Resource
                 Tables\Columns\TextColumn::make('queue')
                     ->label(__('filament-jobs-monitor::translations.queue'))
                     ->sortable(),
+                Tables\Columns\TextColumn::make('progress')
+                    ->label(__('filament-jobs-monitor::translations.progress'))
+                    ->formatStateUsing(fn (string $state) => "{$state}%")
+                    ->sortable(),
                 // ProgressColumn::make('progress')->label(__('filament-jobs-monitor::translations.progress'))->color('warning'),
                 Tables\Columns\TextColumn::make('started_at')
                     ->label(__('filament-jobs-monitor::translations.started_at'))

--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -103,6 +103,11 @@ class QueueMonitorResource extends Resource
         return FilamentJobsMonitorPlugin::get()->getNavigationGroup();
     }
 
+    public static function getNavigationSort(): ?int
+    {
+        return FilamentJobsMonitorPlugin::get()->getNavigationSort();
+    }
+
     public static function getBreadcrumb(): string
     {
         return FilamentJobsMonitorPlugin::get()->getBreadcrumb();

--- a/src/Resources/QueueMonitorResource/Pages/ListQueueMonitors.php
+++ b/src/Resources/QueueMonitorResource/Pages/ListQueueMonitors.php
@@ -8,21 +8,21 @@ use Filament\Resources\Pages\ListRecords;
 
 class ListQueueMonitors extends ListRecords
 {
-    protected static string $resource = QueueMonitorResource::class;
+    public static string $resource = QueueMonitorResource::class;
 
-    protected function getActions(): array
+    public function getActions(): array
     {
         return [];
     }
 
-    protected function getHeaderWidgets(): array
+    public function getHeaderWidgets(): array
     {
         return [
             QueueStatsOverview::class,
         ];
     }
 
-    protected function getTitle(): string
+    public function getTitle(): string
     {
         return __('filament-jobs-monitor::translations.title');
     }


### PR DESCRIPTION
This adds Filament v3 support as well as a plugin class to register the plugin to the panel with configuration.

```php
return $panel
    ->plugins([
        \Croustibat\FilamentJobsMonitor\FilamentJobsMonitorPlugin::make()
            ->label('Job')
            ->pluralLabel('Jobs')
            ->enableNavigation(true)
            ->navigationIcon('heroicon-o-cpu-chip')
            ->navigationGroup('Settings')
            ->navigationSort(5)
            ->navigationCountBadge(true)
            ->enablePruning(true)
            ->pruningRetention(7)
            ->resource(\App\Filament\Resources\CustomJobMonitorResource::class)
    ]);
```

## Todo

- [ ] Update [filament-progress-column](https://github.com/ryangjchandler/filament-progress-column) and add it back to the plugin.

## Change log

- ✨ Add support for Filament v3
- 🔧 Implement a configurable panel plugin class
- 🔧 Make table columns sortable (Supersedes #15)
- 🔧 Add a configurable navigation menu resource sort order (Supersedes #18)
- 🔧 Add a toggle to show a job count badge in the navigation menu
- 🔧 Add a configuration option to customize the QueueMonitorResource model
- 🔧 Split the resource label into singular and plural
- 🔧 Update plugin config to reflect v3 changes
- 🔧 Make the `ListQueueMonitors` methods `public` to coincide with Filament v3
- 🚨 Run Pint
