### PR TITLE
Fix for no getJobId() in job finishing

### DIFF
--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -59,11 +59,7 @@ class QueueMonitor extends Model
 
     public static function getJobId(JobContract $job): string|int
     {
-        if ($jobId = $job->getJobId()) {
-            return $jobId;
-        }
-
-        return Hash::make($job->getRawBody());
+        return $job->payload()['uuid'] ?? Hash::make($job->getRawBody());
     }
 
     /**


### PR DESCRIPTION
When running the jobs with sync connection there is no getJobId() in Queue::after.

As result the monitor job never gets finished. I think replacing the job id with payload's uuid should fix that problem!?