### PR TITLE
handle queue size when using multiple queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,13 @@ return [
         'enabled' => true,
         'retention_days' => 7,
     ],
+    'queues' => [
+        'default'
+    ],
 ];
 ```
+
+**NOTE:** Since there isn't a universal way to retrieve all used queues, it's necessary to define them to obtain all pending jobs. 
 
 ### Extending Model
 

--- a/config/filament-jobs-monitor.php
+++ b/config/filament-jobs-monitor.php
@@ -15,4 +15,7 @@ return [
         'enabled' => true,
         'retention_days' => 7,
     ],
+    'queues' => [
+        'default'
+    ],
 ];

--- a/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
+++ b/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
@@ -22,9 +22,13 @@ class QueueStatsOverview extends BaseWidget
             ->select($aggregationColumns)
             ->first();
 
+        $queueSize = collect(config('filament-jobs-monitor.queues') ?? ['default'])
+            ->map(fn(string $queue): int => Queue::size($queue))
+            ->sum();
+
         return [
             Card::make(__('filament-jobs-monitor::translations.total_jobs'), $aggregatedInfo->count ?? 0),
-            Card::make(__('filament-jobs-monitor::translations.pending_jobs'), Queue::size()),
+            Card::make(__('filament-jobs-monitor::translations.pending_jobs'), $queueSize),
             Card::make(__('filament-jobs-monitor::translations.execution_time'), ($aggregatedInfo->total_time_elapsed ?? 0).'s'),
             Card::make(__('filament-jobs-monitor::translations.average_time'), ceil((float) $aggregatedInfo->average_time_elapsed).'s' ?? 0),
         ];


### PR DESCRIPTION
Since there isn't a universal way to retrieve all used queues, it's necessary to define them to obtain all pending jobs.