### PR TITLE
Update ListQueueMonitors.php

### DIFF
--- a/src/Resources/QueueMonitorResource/Pages/ListQueueMonitors.php
+++ b/src/Resources/QueueMonitorResource/Pages/ListQueueMonitors.php
@@ -26,4 +26,9 @@ class ListQueueMonitors extends ListRecords
     {
         return __('filament-jobs-monitor::translations.title');
     }
+
+    public static function getResource(): string
+    {
+        return config('filament-jobs-monitor.resources.resource') ?? static::$resource;
+    }
 }


### PR DESCRIPTION
It is necessary to add resource acquisition, otherwise the class from config/filament-jobs-monitor.php does not work Why it is impossible to expand the resource