### PR TITLE
Disable sorting and searching for status column

### DIFF
--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -58,7 +58,9 @@ class QueueMonitorResource extends Resource
                         'running' => 'primary',
                         'succeeded' => 'success',
                         'failed' => 'danger',
-                    }),
+                    })
+                    ->sortable(false)
+                    ->searchable(false),
                 TextColumn::make('name')
                     ->label(__('filament-jobs-monitor::translations.name'))
                     ->sortable(),


### PR DESCRIPTION
As there is no status column in the queue_monitors table, if you configure your columns to be searchable or sortable by default this will throw column not found exceptions when sorting or searching

```PHP
Column::configureUsing(function (Column $column): void {
    $column->toggleable()->searchable()->sortable();
});
```