### PR TITLE
changed tenantId to str, beca

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class MyTenantJob implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public function __construct(
-        public int $tenantId,  // Required for multi-tenancy
+        public string $tenantId,  // Required for multi-tenancy
         // ... other properties
     ) {}
 }

--- a/database/migrations/create_filament-jobs-monitor_table.php.stub
+++ b/database/migrations/create_filament-jobs-monitor_table.php.stub
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->integer('attempt')->default(0);
             $table->integer('progress')->nullable();
             $table->text('exception_message')->nullable();
-            $table->unsignedBigInteger('tenant_id')->nullable()->index();
+            $table->string('tenant_id')->nullable()->index();
             $table->timestamps();
         });
     }

--- a/examples/TenantAwareExportJob.php
+++ b/examples/TenantAwareExportJob.php
@@ -26,12 +26,12 @@ class TenantAwareExportJob implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param  int  $tenantId  Required for multi-tenancy - the ID of the tenant this job belongs to
+     * @param  string  $tenantId  Required for multi-tenancy - the ID of the tenant this job belongs to
      * @param  Collection  $data  The data to be exported
      * @param  string  $filename  The output filename
      */
     public function __construct(
-        public int $tenantId,
+        public string $tenantId,
         protected Collection $data,
         protected string $filename
     ) {

--- a/src/Models/FailedJob.php
+++ b/src/Models/FailedJob.php
@@ -27,10 +27,11 @@ class FailedJob extends Model
             ?? config('database.default');
     }
 
-    public function scopeForTenant(Builder $query, int $tenantId): Builder
+    public function scopeForTenant(Builder $query, string $tenantId): Builder
     {
         $column = config('filament-jobs-monitor.tenancy.column', 'tenant_id');
+        $strlenTenantId = strlen($tenantId);
 
-        return $query->where('payload', 'LIKE', '%"'.$column.'";i:'.$tenantId.';%');
+        return $query->where('payload', 'LIKE', '%"'.$column.'";s:'.$strlenTenantId.':"'.$tenantId.'";%');
     }
 }

--- a/src/Models/QueueJob.php
+++ b/src/Models/QueueJob.php
@@ -60,10 +60,11 @@ class QueueJob extends Model
         return $driver === 'database';
     }
 
-    public function scopeForTenant(Builder $query, int $tenantId): Builder
+    public function scopeForTenant(Builder $query, string $tenantId): Builder
     {
         $column = config('filament-jobs-monitor.tenancy.column', 'tenant_id');
+        $strlenTenantId = strlen($tenantId);
 
-        return $query->where('payload', 'LIKE', '%"'.$column.'";i:'.$tenantId.';%');
+        return $query->where('payload', 'LIKE', '%"'.$column.'";s:'.$strlenTenantId.':"'.$tenantId.'";%');
     }
 }

--- a/src/QueueMonitorProvider.php
+++ b/src/QueueMonitorProvider.php
@@ -54,7 +54,7 @@ class QueueMonitorProvider extends ServiceProvider
     /**
      * Extract tenant ID from job payload.
      */
-    protected static function getTenantIdFromJob(JobContract $job): ?int
+    protected static function getTenantIdFromJob(JobContract $job): ?string
     {
         if (! config('filament-jobs-monitor.tenancy.enabled')) {
             return null;

--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -75,6 +75,8 @@ class QueueMonitorResource extends Resource
                     })
                     ->sortable(false)
                     ->searchable(false),
+                TextColumn::make('tenant_id')
+                    ->visible(config('filament-jobs-monitor.tenancy.enabled')),
                 TextColumn::make('name')
                     ->label(__('filament-jobs-monitor::translations.name'))
                     ->sortable(),

--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -268,6 +268,23 @@ class QueueMonitorResource extends Resource
                                 ->send();
                         }
                     }),
+
+                    Action::make('clearAllLogs')
+                        ->label('Clear all logs')
+                        ->icon('heroicon-o-trash')
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->modalHeading('Clear all logs?')
+                        ->modalDescription('This will permanently remove all queue monitor records.')
+                        ->modalSubmitActionLabel('Yes, clear all')
+                        ->action(function () {
+                            \DB::table('queue_monitors')->truncate();
+
+                            Notification::make()
+                                ->title('Queue monitor logs cleared')
+                                ->success()
+                                ->send();
+                        }),
             ])
             ->filters([
                 SelectFilter::make('status')

--- a/tests/Feature/MultiTenancyTest.php
+++ b/tests/Feature/MultiTenancyTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 it('returns null tenant id when tenancy is disabled', function () {
     config()->set('filament-jobs-monitor.tenancy.enabled', false);
 
-    $job = createMockJobWithTenantId(123);
+    $job = createMockJobWithTenantId('123');
     $tenantId = invokeTenantIdExtraction($job);
 
     expect($tenantId)->toBeNull();
@@ -23,10 +23,10 @@ it('returns null tenant id when tenancy is disabled', function () {
 it('extracts tenant id from job payload when tenancy is enabled', function () {
     config()->set('filament-jobs-monitor.tenancy.enabled', true);
 
-    $job = createMockJobWithTenantId(456);
+    $job = createMockJobWithTenantId('456');
     $tenantId = invokeTenantIdExtraction($job);
 
-    expect($tenantId)->toBe(456);
+    expect($tenantId)->toBe('456');
 });
 
 it('returns null when job has no tenant id property', function () {
@@ -63,7 +63,7 @@ it('returns null when command cannot be unserialized', function () {
 });
 
 it('QueueJob forTenant scope filters by tenant id in payload', function () {
-    $tenantId = 789;
+    $tenantId = '789';
 
     $query = QueueJob::query()->forTenant($tenantId);
     $sql = $query->toSql();
@@ -73,7 +73,7 @@ it('QueueJob forTenant scope filters by tenant id in payload', function () {
 });
 
 it('FailedJob forTenant scope filters by tenant id in payload', function () {
-    $tenantId = 101;
+    $tenantId = '101';
 
     $query = FailedJob::query()->forTenant($tenantId);
     $sql = $query->toSql();
@@ -90,7 +90,7 @@ it('FailedJob forTenant scope filters by tenant id in payload', function () {
 
 class TenantJobStub
 {
-    public function __construct(public int $tenantId) {}
+    public function __construct(public string $tenantId) {}
 }
 
 class NonTenantJobStub
@@ -98,7 +98,7 @@ class NonTenantJobStub
     public string $someProperty = 'value';
 }
 
-function createMockJobWithTenantId(int $tenantId): JobContract
+function createMockJobWithTenantId(string $tenantId): JobContract
 {
     $command = new TenantJobStub($tenantId);
 


### PR DESCRIPTION
Other projects than the native (like tenancyforlaravel) use string-based tenant ids.
Which wont work with the original int tenant id.
The string based tenant ids could work with both str/int based tenant ids. Also added a 'clear logs' button.