### PR TITLE
Add a button to clear all current logs from table

### DIFF
--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -273,6 +273,24 @@ class QueueMonitorResource extends Resource
                                 ->send();
                         }
                     }),
+
+
+                Action::make('clearLogs')
+                        ->label('Clear logs')
+                        ->icon('heroicon-o-trash')
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->modalHeading('Clear all logs?')
+                        ->modalDescription('This will permanently remove all queue monitor records.')
+                        ->modalSubmitActionLabel('Yes, clear all')
+                        ->action(function () {
+                            \DB::table('queue_monitors')->truncate();
+
+                            Notification::make()
+                                ->title('Queue monitor logs cleared')
+                                ->success()
+                                ->send();
+                        }),
             ])
             ->filters([
                 SelectFilter::make('status')


### PR DESCRIPTION
Hi @croustibat I read your message, but havent had time to respond. This is the pr for the clear-logs-button.
I'm thinking about giving the tenant_id the types: int|string, so that its backward compatibel. Is that an idea?