### PR TITLE
fix: use $record in details action modal closure

### DIFF
--- a/src/Resources/QueueMonitorResource.php
+++ b/src/Resources/QueueMonitorResource.php
@@ -147,10 +147,10 @@ class QueueMonitorResource extends Resource
                 Action::make('details')
                     ->label(__('filament-jobs-monitor::translations.details'))
                     ->icon('heroicon-o-information-circle')
-                    ->modalContent(fn ($queueMonitor) => view('filament-jobs-monitor::queue-monitor-details', [
-                        'exception_message' => $queueMonitor->exception_message,
-                        'failed' => $queueMonitor->failed,
-                        'attempts' => $queueMonitor->attempt,
+                    ->modalContent(fn ($record) => view('filament-jobs-monitor::queue-monitor-details', [
+                        'exception_message' => $record->exception_message,
+                        'failed' => $record->failed,
+                        'attempts' => $record->attempt,
                     ]))
                     ->modalSubmitAction(false),
             ])


### PR DESCRIPTION
## Summary
The `details` table action on `QueueMonitorResource` crashes with `Attempt to read property "exception_message" on null` when clicked.

The `modalContent` closure receives a null argument because it uses the parameter name `$queueMonitor` instead of `$record`, which is what Filament 5 injects into action closures.

## Fix
Rename the parameter to `$record`, matching the convention already used by the `retry` action in the same file.

## Repro
1. Navigate to the Queue Monitor page.
2. Click the "Details" action on any row.
3. Without this patch: 500 ViewException.
4. With this patch: modal opens normally.