### PR TITLE
Remove an unnecessary (duplicate) line from the config file

### DIFF
--- a/config/filament-jobs-monitor.php
+++ b/config/filament-jobs-monitor.php
@@ -13,7 +13,6 @@ return [
         'navigation_group' => 'Settings',
         'navigation_icon' => 'heroicon-o-cpu-chip',
         'navigation_sort' => null,
-        'sub_navigation_position' => null,
         'navigation_count_badge' => false,
         'resource' => QueueMonitorResource::class,
         'cluster' => null,


### PR DESCRIPTION
This key is duplicate and is set few lines later a second time, with some additional explanation.