### PR TITLE
Fix: N+1 in stats queries

### DIFF
--- a/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
+++ b/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
@@ -4,9 +4,11 @@ namespace Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource\Widgets;
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
+use Closure;
 use Croustibat\FilamentJobsMonitor\Models\QueueMonitor;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Number;
@@ -67,43 +69,41 @@ class QueueStatsOverview extends BaseWidget
 
     private function getJobsPerDay(int $days): array
     {
-        $data = [];
-        $model = resolve(QueueMonitor::class);
-
-        for ($i = $days - 1; $i >= 0; $i--) {
-            $date = Carbon::now()->subDays($i)->toDateString();
-            $data[] = $model::whereDate('created_at', $date)->count();
-        }
-
-        return $data;
+        return $this->countPerDay($days);
     }
 
     private function getSucceededJobsPerDay(int $days): array
     {
-        $data = [];
-        $model = resolve(QueueMonitor::class);
-
-        for ($i = $days - 1; $i >= 0; $i--) {
-            $date = Carbon::now()->subDays($i)->toDateString();
-            $data[] = $model::whereDate('created_at', $date)
-                ->whereNotNull('finished_at')
-                ->where('failed', false)
-                ->count();
-        }
-
-        return $data;
+        return $this->countPerDay($days, fn (Builder $query): Builder => $query
+            ->whereNotNull('finished_at')
+            ->where('failed', false));
     }
 
     private function getFailedJobsPerDay(int $days): array
     {
+        return $this->countPerDay($days, fn (Builder $query): Builder => $query
+            ->whereNotNull('finished_at')
+            ->where('failed', true));
+    }
+
+    private function countPerDay(int $days, ?Closure $constrain = null): array
+    {
+        $query = resolve(QueueMonitor::class)::query()
+            ->where('created_at', '>=', Carbon::now()->subDays($days - 1)->startOfDay());
+
+        if ($constrain !== null) {
+            $query = $constrain($query);
+        }
+
+        $countsByDay = $query
+            ->get(['created_at'])
+            ->countBy(fn (QueueMonitor $monitor): string => $monitor->created_at->toDateString());
+
         $data = [];
-        $model = resolve(QueueMonitor::class);
+
         for ($i = $days - 1; $i >= 0; $i--) {
             $date = Carbon::now()->subDays($i)->toDateString();
-            $data[] = $model::whereDate('created_at', $date)
-                ->whereNotNull('finished_at')
-                ->where('failed', true)
-                ->count();
+            $data[] = $countsByDay->get($date, 0);
         }
 
         return $data;


### PR DESCRIPTION
I have two errors reported by Sentry:


```
select count(*) as "aggregate" from "fm_queue_monitors" where "created_at"::date = ?
in
livewire?component=Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource\Widgets\QueueStatsOverview
```

and

```
select count(*) as "aggregate" from "fm_queue_monitors" where "created_at"::date = ? and "finished_at" is not null and "failed" = ?
in
livewire?component=Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource\Widgets\QueueStatsOverview
```

This PR fixes both reports.