### PR TITLE
fix: prune QueueMonitor records via a dedicated command (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,42 @@ php artisan filament:assets
 
 If the migration has not been run, the plugin keeps working as before and simply skips failure grouping.
 
+### Pruning old records
+
+The `QueueMonitor` model uses Laravel's [`Prunable`](https://laravel.com/docs/eloquent#pruning-models) trait and will prune records older than `pruning.retention_days` (default: 7 days) when `pruning.enabled` is `true`.
+
+> **Important:** Laravel's built-in `php artisan model:prune` command only **auto-discovers** prunable models that live in your application's `app/Models` directory. Because `QueueMonitor` is shipped inside this package (`vendor/...`), it is **never** picked up by a bare `model:prune` call — this is the most common cause of "the model is not pruning".
+
+You have two ways to prune the records:
+
+**1. Use the dedicated command shipped with this package (recommended):**
+
+```bash
+php artisan filament-jobs-monitor:prune
+```
+
+This targets the package model directly, so it works regardless of your app structure. Schedule it in `routes/console.php` (Laravel 11+) or `app/Console/Kernel.php`:
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('filament-jobs-monitor:prune')->daily();
+```
+
+**2. Or call Laravel's `model:prune` with an explicit `--model` flag:**
+
+```bash
+php artisan model:prune --model="Croustibat\FilamentJobsMonitor\Models\QueueMonitor"
+```
+
+Pruning can also be toggled/configured at the plugin level:
+
+```php
+FilamentJobsMonitorPlugin::make()
+    ->enablePruning() // or ->enablePruning(false) to disable
+    ->pruningRetention(14); // keep records for 14 days
+```
+
 ### Extending Model
 
 Sometimes it's useful to extend the model to add some custom methods. You can do it by extending the model by creating your own model :

--- a/src/Commands/PruneQueueMonitorCommand.php
+++ b/src/Commands/PruneQueueMonitorCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Croustibat\FilamentJobsMonitor\Commands;
+
+use Croustibat\FilamentJobsMonitor\Models\QueueMonitor;
+use Illuminate\Console\Command;
+
+class PruneQueueMonitorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'filament-jobs-monitor:prune';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune the filament-jobs-monitor records using the configured retention.';
+
+    /**
+     * Execute the console command.
+     *
+     * Laravel's built-in `model:prune` command only auto-discovers prunable
+     * models living in the application's `app/Models` directory, so the
+     * package's QueueMonitor model is never reached unless an explicit
+     * `--model=` flag is passed. This dedicated command targets the package
+     * model directly so pruning works out of the box for a package install.
+     */
+    public function handle(): int
+    {
+        $this->components->info('Pruning '.QueueMonitor::class);
+
+        $total = $this->getModel()->pruneAll();
+
+        if ($total === 0) {
+            $this->components->info('No '.QueueMonitor::class.' records to prune.');
+        } else {
+            $this->components->info($total.' '.QueueMonitor::class.' records pruned.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Resolve the prunable model instance.
+     */
+    protected function getModel(): QueueMonitor
+    {
+        return new QueueMonitor;
+    }
+}

--- a/src/FilamentJobsMonitorServiceProvider.php
+++ b/src/FilamentJobsMonitorServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Croustibat\FilamentJobsMonitor;
 
+use Croustibat\FilamentJobsMonitor\Commands\PruneQueueMonitorCommand;
 use Filament\Support\Assets\Css;
 use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
@@ -20,7 +21,8 @@ class FilamentJobsMonitorServiceProvider extends PackageServiceProvider
             ->hasMigrations([
                 'create_filament-jobs-monitor_table',
                 'add_failures_to_filament-jobs-monitor_table',
-            ]);
+            ])
+            ->hasCommand(PruneQueueMonitorCommand::class);
     }
 
     public function packageRegistered(): void

--- a/src/Models/QueueMonitor.php
+++ b/src/Models/QueueMonitor.php
@@ -146,14 +146,16 @@ class QueueMonitor extends Model
     /**
      * Get the prunable model query.
      *
-     * @return Builder
+     * When pruning is disabled we return a query that matches nothing rather
+     * than a boolean, so Laravel's pruneAll() (which calls ->when() on the
+     * result) stays a safe no-op instead of crashing on a false value.
      */
-    public function prunable(): Builder|bool
+    public function prunable(): Builder
     {
         if (FilamentJobsMonitorPlugin::get()->getPruning()) {
             return static::where('created_at', '<=', now()->subDays(FilamentJobsMonitorPlugin::get()->getPruningRetention()));
         }
 
-        return false;
+        return static::query()->whereRaw('1 = 0');
     }
 }

--- a/tests/Feature/PruningTest.php
+++ b/tests/Feature/PruningTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Croustibat\FilamentJobsMonitor\FilamentJobsMonitorPlugin;
+use Croustibat\FilamentJobsMonitor\Models\QueueMonitor;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    // Load the package migration into the in-memory sqlite database.
+    if (! Schema::hasTable('queue_monitors')) {
+        $migration = include __DIR__.'/../../database/migrations/create_filament-jobs-monitor_table.php.stub';
+        $migration->up();
+    }
+
+    config()->set('filament-jobs-monitor.pruning.enabled', true);
+    config()->set('filament-jobs-monitor.pruning.retention_days', 7);
+
+    // Reset any plugin overrides between tests.
+    app()->forgetInstance(FilamentJobsMonitorPlugin::class);
+
+    QueueMonitor::query()->delete();
+});
+
+function createMonitor(int $daysOld): QueueMonitor
+{
+    $monitor = QueueMonitor::create([
+        'job_id' => (string) Str::uuid(),
+        'name' => 'TestJob',
+        'queue' => 'default',
+        'failed' => false,
+        'attempt' => 1,
+    ]);
+
+    $createdAt = now()->subDays($daysOld);
+    $monitor->forceFill([
+        'created_at' => $createdAt,
+        'updated_at' => $createdAt,
+    ])->saveQuietly();
+
+    return $monitor;
+}
+
+it('prunes records older than the retention period', function () {
+    createMonitor(10); // older than 7 days -> should be pruned
+    createMonitor(3);  // newer than 7 days -> should be kept
+
+    expect(QueueMonitor::count())->toBe(2);
+
+    $pruned = (new QueueMonitor)->pruneAll();
+
+    expect($pruned)->toBe(1)
+        ->and(QueueMonitor::count())->toBe(1);
+});
+
+it('does not prune anything when pruning is disabled', function () {
+    config()->set('filament-jobs-monitor.pruning.enabled', false);
+    app()->forgetInstance(FilamentJobsMonitorPlugin::class);
+
+    createMonitor(30);
+
+    $pruned = (new QueueMonitor)->pruneAll();
+
+    expect($pruned)->toBe(0)
+        ->and(QueueMonitor::count())->toBe(1);
+});
+
+it('prunes via the dedicated artisan command', function () {
+    createMonitor(10);
+    createMonitor(2);
+
+    $this->artisan('filament-jobs-monitor:prune')
+        ->assertSuccessful();
+
+    expect(QueueMonitor::count())->toBe(1);
+});


### PR DESCRIPTION
## Problem

The `QueueMonitor` model uses Laravel's `Prunable` trait, but records were never pruned: `php artisan model:prune` only **auto-discovers** prunable models under `app/Models`. Since `QueueMonitor` ships inside the package (`vendor/...`), a bare `model:prune` never reaches it.

Closes #120.

## Solution

- **New dedicated command** `php artisan filament-jobs-monitor:prune` that prunes the package model directly (standard approach, cf. `telescope:prune`), registered via `->hasCommand()` in the service provider.
- **Fix `prunable()`**: when pruning is disabled it returned `false`, which crashed `pruneAll()` (`Call to a member function when() on false`). It now returns a query that matches nothing → safe no-op.
- **README** documentation (dedicated command + explicit `model:prune --model=...` + plugin-level configuration).

## Tests

`tests/Feature/PruningTest.php` (3 tests): prunes records older than the retention period; does nothing when pruning is disabled (covers the crash above); prunes via the dedicated artisan command.
