### PR TITLE
style: add space in (int) cast (cast_spaces)

### DIFF
--- a/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
+++ b/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
@@ -32,7 +32,7 @@ class QueueStatsOverview extends BaseWidget
             ->sum();
 
         $totalJobs = Number::format($aggregatedInfo->count ?? 0);
-        $executionTime = CarbonInterval::seconds((int)$aggregatedInfo->total_time_elapsed)->cascade()->forHumans(short: true, parts: 3);
+        $executionTime = CarbonInterval::seconds((int) $aggregatedInfo->total_time_elapsed)->cascade()->forHumans(short: true, parts: 3);
 
         // Get job counts for the last 7 days for charts
         $jobsPerDay = $this->getJobsPerDay(7);


### PR DESCRIPTION
Follow-up to #123. The int cast in `QueueStatsOverview` landed without the space required by the Laravel Pint preset (`cast_spaces`), leaving the style workflow red on `main` (it can't auto-commit to protected `main`). This applies the fix so Pint passes.