### PR TITLE
feat: discover tenant id for queued events/listeners (finalizes #115)

### DIFF
--- a/config/filament-jobs-monitor.php
+++ b/config/filament-jobs-monitor.php
@@ -45,5 +45,8 @@ return [
         'enabled' => false,
         'model' => null,
         'column' => 'tenant_id',
+        // Payload key inspected on queued jobs/listeners to resolve the tenant id
+        // before falling back to the serialized command's `tenantId` property.
+        'payload_key' => 'tenant_id',
     ],
 ];

--- a/src/QueueMonitorProvider.php
+++ b/src/QueueMonitorProvider.php
@@ -64,9 +64,10 @@ class QueueMonitorProvider extends ServiceProvider
 
         $payload = $job->payload();
 
-        if (! isset($payload['data']['command'])) {
-            return null;
-        }
+        // Events have tenantId directly on the payload, not on the command object
+        if (isset($payload['tenantId'])) return $payload['tenantId'];
+
+        if (! isset($payload['data']['command'])) return null;
 
         try {
             $command = unserialize($payload['data']['command']);

--- a/src/QueueMonitorProvider.php
+++ b/src/QueueMonitorProvider.php
@@ -5,6 +5,7 @@ namespace Croustibat\FilamentJobsMonitor;
 use Croustibat\FilamentJobsMonitor\Models\FailureGroup;
 use Croustibat\FilamentJobsMonitor\Models\QueueMonitor;
 use Illuminate\Contracts\Queue\Job as JobContract;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
@@ -58,15 +59,21 @@ class QueueMonitorProvider extends ServiceProvider
      */
     protected static function getTenantIdFromJob(JobContract $job): null|int|string
     {
-        if (! config('filament-jobs-monitor.tenancy.enabled')) return null;
+        if (! config('filament-jobs-monitor.tenancy.enabled')) {
+            return null;
+        }
 
         $payload = $job->payload();
 
         // Try and get the tenantId from the payload key.
-        $payload_key = config('filament-jobs-monitor.tenancy.payload_key', 'tenant_id');
-        if (isset($payload[$payload_key])) return $payload[$payload_key];
+        $payloadKey = config('filament-jobs-monitor.tenancy.payload_key', 'tenant_id');
+        if (isset($payload[$payloadKey])) {
+            return $payload[$payloadKey];
+        }
 
-        if (! isset($payload['data']['command'])) return null;
+        if (! isset($payload['data']['command'])) {
+            return null;
+        }
 
         try {
             $command = unserialize($payload['data']['command']);
@@ -77,7 +84,7 @@ class QueueMonitorProvider extends ServiceProvider
             }
 
             // Queued event listener: extract tenantId from the event passed to the listener
-            if ($command instanceof \Illuminate\Events\CallQueuedListener) {
+            if ($command instanceof CallQueuedListener) {
                 $event = $command->data[0] ?? null;
                 if ($event && property_exists($event, 'tenantId')) {
                     return $event->tenantId;

--- a/src/QueueMonitorProvider.php
+++ b/src/QueueMonitorProvider.php
@@ -64,15 +64,27 @@ class QueueMonitorProvider extends ServiceProvider
 
         $payload = $job->payload();
 
-        // Events have tenantId directly on the payload, not on the command object
-        if (isset($payload['tenantId'])) return $payload['tenantId'];
-
-        if (! isset($payload['data']['command'])) return null;
+        if (! isset($payload['data']['command'])) {
+            return null;
+        }
 
         try {
             $command = unserialize($payload['data']['command']);
 
-            return $command->tenantId ?? null;
+            // Regular job: check for tenantId property on the command itself
+            if (property_exists($command, 'tenantId')) {
+                return $command->tenantId;
+            }
+
+            // Queued event listener: extract tenantId from the event passed to the listener
+            if ($command instanceof \Illuminate\Events\CallQueuedListener) {
+                $event = $command->data[0] ?? null;
+                if ($event && property_exists($event, 'tenantId')) {
+                    return $event->tenantId;
+                }
+            }
+
+            return null;
         } catch (\Throwable) {
             return null;
         }

--- a/src/QueueMonitorProvider.php
+++ b/src/QueueMonitorProvider.php
@@ -58,15 +58,15 @@ class QueueMonitorProvider extends ServiceProvider
      */
     protected static function getTenantIdFromJob(JobContract $job): null|int|string
     {
-        if (! config('filament-jobs-monitor.tenancy.enabled')) {
-            return null;
-        }
+        if (! config('filament-jobs-monitor.tenancy.enabled')) return null;
 
         $payload = $job->payload();
 
-        if (! isset($payload['data']['command'])) {
-            return null;
-        }
+        // Try and get the tenantId from the payload key.
+        $payload_key = config('filament-jobs-monitor.tenancy.payload_key', 'tenant_id');
+        if (isset($payload[$payload_key])) return $payload[$payload_key];
+
+        if (! isset($payload['data']['command'])) return null;
 
         try {
             $command = unserialize($payload['data']['command']);


### PR DESCRIPTION
Rebased and finalized version of #115 by @zerdotre.

## What

Extends tenant id discovery to queued **events/listeners** (not only jobs): reads a configurable payload key `tenancy.payload_key` (default `tenant_id`) and, for `Illuminate\Events\CallQueuedListener`, extracts `tenantId` from the wrapped event.

## Finalization on top of the original PR

- Declared the missing `tenancy.payload_key` config key (default `tenant_id`).
- Applied the Laravel Pint code style (braces on the guard clauses).
- Rebased on current `main`; Pint and the full Pest suite are green (25 passed).

Supersedes #115.
