### PR TITLE
fix: stats widget execution-time aggregates on SQLite/MySQL (#55)

### DIFF
--- a/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
+++ b/src/Resources/QueueMonitorResource/Widgets/QueueStatsOverview.php
@@ -122,10 +122,15 @@ class QueueStatsOverview extends BaseWidget
 
     private function dbColumnAsInteger(string $colName): string
     {
-        if (DB::connection()->getConfig('driver') === 'pgsql') {
-            return sprintf('CAST(EXTRACT(EPOCH FROM %s) AS INTEGER)', $colName);
-        }
-
-        return $colName;
+        // Convert a datetime column to epoch seconds using each driver's own
+        // function, so the duration aggregates work on SQLite/MySQL/Postgres
+        // alike. Falling back to a raw column subtraction is wrong on SQLite
+        // (string coercion yields 0) — see issue #55.
+        return match (DB::connection()->getConfig('driver')) {
+            'pgsql' => sprintf('CAST(EXTRACT(EPOCH FROM %s) AS INTEGER)', $colName),
+            'sqlite' => "CAST(strftime('%s', {$colName}) AS INTEGER)",
+            'mysql', 'mariadb' => sprintf('UNIX_TIMESTAMP(%s)', $colName),
+            default => $colName,
+        };
     }
 }

--- a/tests/Feature/QueueStatsOverviewTest.php
+++ b/tests/Feature/QueueStatsOverviewTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Croustibat\FilamentJobsMonitor\Models\QueueMonitor;
+use Croustibat\FilamentJobsMonitor\Resources\QueueMonitorResource\Widgets\QueueStatsOverview;
+
+beforeEach(function () {
+    $migration = include __DIR__.'/../../database/migrations/create_filament-jobs-monitor_table.php.stub';
+    $migration->up();
+});
+
+it('computes execution time stats on the current database driver', function () {
+    // Two finished jobs lasting 10s and 20s -> total 30s, average 15s.
+    QueueMonitor::create([
+        'job_id' => 'uuid-a',
+        'name' => 'App\Jobs\FooJob',
+        'queue' => 'default',
+        'started_at' => '2024-01-01 00:00:00',
+        'finished_at' => '2024-01-01 00:00:10',
+        'failed' => false,
+        'attempt' => 1,
+    ]);
+
+    QueueMonitor::create([
+        'job_id' => 'uuid-b',
+        'name' => 'App\Jobs\FooJob',
+        'queue' => 'default',
+        'started_at' => '2024-01-01 00:00:00',
+        'finished_at' => '2024-01-01 00:00:20',
+        'failed' => false,
+        'attempt' => 1,
+    ]);
+
+    $stats = (new ReflectionMethod(QueueStatsOverview::class, 'getStats'))
+        ->invoke(new QueueStatsOverview);
+
+    // The average execution time is computed by the database engine; with the
+    // old SQLite-incompatible query this was "0s" (see issue #55).
+    expect($stats)->toHaveCount(4)
+        ->and($stats[3]->getValue())->toBe('15s');
+});


### PR DESCRIPTION
## Problem

Issue #55: the queue stats widget didn't work on SQLite. The execution-time aggregates (`total_time_elapsed`, `average_time_elapsed`) were built with a driver switch that only handled PostgreSQL; every other driver fell back to a raw `finished_at - started_at` column subtraction. On SQLite that yields `0` (datetime strings coerced to numbers), and on MySQL it produces meaningless values.

## Fix

`dbColumnAsInteger()` now converts a datetime column to epoch seconds with each engine's own function:

- **SQLite**: `strftime('%s', col)`
- **MySQL / MariaDB**: `UNIX_TIMESTAMP(col)`
- **PostgreSQL**: `EXTRACT(EPOCH FROM col)` (unchanged)

The per-day counters were already made portable via `countBy()` in #121, so the widget is now fully driver-agnostic.

## Test

`tests/Feature/QueueStatsOverviewTest.php` seeds two finished jobs (10s and 20s) and asserts the average execution time is `15s` when running on SQLite — which returned `0s` before the fix.

Closes #55.
