### PR TITLE
chore: update CHANGELOG for v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `filament-jobs-monitor` will be documented in this file.
 
-## Unreleased
+## 4.6.0 - 2026-08-24
 
 ### Added
 


### PR DESCRIPTION
Dates the `Unreleased` section as **4.6.0** ahead of tagging.

Content shipped since v4.5.0:

- **Added** — complete `ru` locale (#146), translated "Clear logs" action with six new `en` keys (#146), localised resource labels and navigation group (#146), Polish translations for the Failures page (#131), translation parity test (#144).
- **Changed** — `navigation_group` now actually renders its translation key; its `en` value moved from `System` to `Settings`.
- **Fixed** — configured labels no longer collide with the host JSON catalogue (#146), plugin stylesheet wrapped in `@layer components` so it stops overriding the host app's Tailwind utilities (#145, #147).

No code change, CHANGELOG only. Tag `v4.6.0` and the GitHub release follow once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)